### PR TITLE
Prevent horizontal scrolling on mobile device

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,35 +13,37 @@
 </head>
 
 <body>
-    <img src="img/hertaa1.gif" class="preload" />
-    <img src="img/hertaa2.gif" class="preload" />
-    <div id="content">
-        <h1>Welcome to herta kuru</h1>
-        <hr id="subtitle-seperator" />
-        <h2>
-            The website for Herta, the <del>annoying</del> cutest genius Honkai:
-            Star Rail character out there.
-        </h2>
-        <div id="counter-container">
-            <h3>The kuru~ has been squished</h3>
-            <br />
-            <br />
-            <p id="global-counter">0</p>
-            <p id="local-counter">0</p>
-            <br />
-            <br />
-            <p>times</p>
-            <button id="counter-button">
-                Squish the kuru~!
-            </button>
+    <main class="wrapper">
+        <img src="img/hertaa1.gif" class="preload" />
+        <img src="img/hertaa2.gif" class="preload" />
+        <div id="content">
+            <h1>Welcome to herta kuru</h1>
+            <hr id="subtitle-seperator" />
+            <h2>
+                The website for Herta, the <del>annoying</del> cutest genius Honkai:
+                Star Rail character out there.
+            </h2>
+            <div id="counter-container">
+                <h3>The kuru~ has been squished</h3>
+                <br />
+                <br />
+                <p id="global-counter">0</p>
+                <p id="local-counter">0</p>
+                <br />
+                <br />
+                <p>times</p>
+                <button id="counter-button">
+                    Squish the kuru~!
+                </button>
+            </div>
+            <hr />
+            <div id="grid">
+                <noscript>Your browser does not support JavaScript or JavaScript has been
+                    disabled.<br />This website relies on JavaScript, so please enable it
+                    or use another browser.</noscript>
+            </div>
         </div>
-        <hr />
-        <div id="grid">
-            <noscript>Your browser does not support JavaScript or JavaScript has been
-                disabled.<br />This website relies on JavaScript, so please enable it
-                or use another browser.</noscript>
-        </div>
-    </div>
+    </main>
     <div id="footer">
         <img id="herta-card" loading="lazy" src="img/card.jpg" alt="" />
         <div id="footer-text">
@@ -63,4 +65,5 @@
     </div>
 </body>
 <script src="script.js" async></script>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -8,6 +8,10 @@ body {
     font-family: 'Roboto', sans-serif;
     font-size: 1.5em;
     color: white;
+}
+
+.wrapper {
+    position: relative;
     overflow-x: hidden;
 }
 
@@ -32,7 +36,7 @@ h1 {
 h2 {
     text-align: center;
     font-weight: bold;
-    font-size: 1.5em;    
+    font-size: 1.5em;
 }
 
 hr {
@@ -47,19 +51,20 @@ hr {
 }
 
 #counter-container {
-    text-align: center; 
+    text-align: center;
     font-weight: bold;
     margin: 64px 0;
 }
 
-#counter-container > p {
-    text-shadow: #9d88d3 0 0 10px,#9d88d3 0 0 10px,#9d88d3 0 0 10px,#9d88d3 0 0 10px,#9d88d3 0 0 10px;
+#counter-container>p {
+    text-shadow: #9d88d3 0 0 10px, #9d88d3 0 0 10px, #9d88d3 0 0 10px, #9d88d3 0 0 10px, #9d88d3 0 0 10px;
 }
 
 #global-counter {
     color: #574f84;
     font-size: 2em;
 }
+
 #local-counter {
     color: #574f84;
     font-size: 0.75em;
@@ -87,7 +92,7 @@ hr {
     background-color: white;
     color: black;
     padding: 16px 10vw;
-    display: flex;    
+    display: flex;
     gap: 16px;
     align-items: center;
     justify-content: center;
@@ -106,7 +111,7 @@ hr {
 .footer-icon {
     display: inline-block;
     vertical-align: middle;
-    font-size: 2em;    
+    font-size: 2em;
 }
 
 #twitter-footer-icon {
@@ -146,7 +151,7 @@ hr {
         font-size: 1.25em;
     }
 
-    #subtitle-seperator {    
+    #subtitle-seperator {
         margin-top: 3px;
         margin-bottom: 11px;
     }
@@ -157,7 +162,7 @@ hr {
         width: calc(100% / 3 - 10px);
     }
 
-    #footer {        
+    #footer {
         flex-wrap: wrap;
     }
 
@@ -180,7 +185,7 @@ hr {
         font-size: 1em;
     }
 
-    #subtitle-seperator {    
+    #subtitle-seperator {
         margin-top: 6px;
         margin-bottom: 12px;
     }
@@ -201,7 +206,7 @@ hr {
         font-size: 1.25em;
     }
 
-    #subtitle-seperator {    
+    #subtitle-seperator {
         margin-top: 8px;
         margin-bottom: 13px;
     }
@@ -218,7 +223,7 @@ hr {
         font-size: 2em;
     }
 
-    #subtitle-seperator {    
+    #subtitle-seperator {
         margin-top: 10px;
     }
 }


### PR DESCRIPTION
On my phone, I was able to scroll to the right side of the page. The problem happens because the image overflows the page and possibly [overflow-x: hidden not properly working on mobile devices](https://stackoverflow.com/questions/14270084/overflow-xhidden-doesnt-prevent-content-from-overflowing-in-mobile-browsers).

I fixed it by:
- Remove `overflow-x: hidden` on the body
- Adding a wrapper tag to the content with `position: relative` and `overflow-x: hidden`

Before:
![mobile-device](https://github.com/duiqt/herta_kuru/assets/7974643/f7923bbe-ce36-45da-9f4d-01cec55d0143)

After:
![mobile-device-fix](https://github.com/duiqt/herta_kuru/assets/7974643/fb6a4363-fde5-4c9e-9369-7861d8c5dc39)

